### PR TITLE
core: add custom traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ use estring::{SepVec, EString};
 type PlusVec<T> = SepVec<T, '+'>;
 type MulVec<T> = SepVec<T, '*'>;
 
-fn main() -> Result<(), estring::ParseError> {
+fn main() -> estring::Result<()> {
     let res = EString::from("10+5*2+3")
         .parse::<PlusVec<MulVec<f32>>>()?
         .iter()
@@ -33,14 +33,15 @@ fn main() -> Result<(), estring::ParseError> {
 }
 ```
 
-You can use custom types as annotations! Just implement `TryFrom<EString>`!
+You can use custom types as annotations! Just implement
+`estring::ParseFragment`!
 
 ## Installation
 
 **The MSRV is 1.59.0**
 
-Add `estring = { version = "0.1", features = ["vec", "number"] }` as a
-dependency in `Cargo.toml`.
+Add `estring = { version = "0.1", features = ["structs"] }` as a dependency in
+`Cargo.toml`.
 
 `Cargo.toml` example:
 
@@ -52,7 +53,7 @@ edition = "2021"
 authors = ["Me <user@rust-lang.org>"]
 
 [dependencies]
-estring = { version = "0.1", features = ["vec", "number"] }
+estring = { version = "0.1", features = ["structs"] }
 ```
 
 ## License

--- a/examples/calc.rs
+++ b/examples/calc.rs
@@ -3,7 +3,7 @@ use estring::{EString, SepVec};
 type PlusVec<T> = SepVec<T, '+'>;
 type MulVec<T> = SepVec<T, '*'>;
 
-fn main() -> Result<(), estring::ParseError> {
+fn main() -> estring::Result<()> {
     let res = EString::from("10+5*2+3")
         .parse::<PlusVec<MulVec<f32>>>()?
         .iter()

--- a/examples/dotenv.rs
+++ b/examples/dotenv.rs
@@ -5,7 +5,7 @@ DATABASE_URL=postgres://user:password@localhost:5432/recipes
 APP_HOST=http://localhost:3000
 ";
 
-fn main() -> Result<(), estring::ParseError> {
+fn main() -> estring::Result<()> {
     EString::from(DOTENV_CONTENT)
         .parse::<Trim<SepVec<Pair<&str, '=', &str>, '\n'>>>()?
         .iter()

--- a/src/core.rs
+++ b/src/core.rs
@@ -11,7 +11,7 @@ pub trait FormatFragment {
 
 /// Parse a value fragment from a ``EString``.
 ///
-/// ``ParseFragment``’s `parse_frag` method is often used imlicitly, through ``EString``’s parse.
+/// ``ParseFragment``’s `parse_frag` method is often used implicitly, through ``EString``’s parse.
 /// See [parse](EString::parse)’s documentation for examples.
 ///
 /// # Examples
@@ -75,12 +75,33 @@ pub trait ParseFragment: Sized {
 pub struct EString(pub String);
 
 impl EString {
-    /// Parses inner string by type annotations and returns result.
+    /// Parses this inner string into another type.
+    ///
+    /// `parse` can parse into any type that implements the ``ParseFragment`` trait.
     ///
     /// # Errors
     ///
-    /// Will return `Err` if estring cannot parse inner fragment
+    /// Will return `Err` if estring cannot parse inner fragment into the desired type.
     ///
+    /// # Examples
+    ///
+    /// Basic usage
+    ///
+    /// ```rust
+    /// # use estring::{EString, ParseFragment};
+    /// let fragment = EString::from("5");
+    /// let res = i32::parse_frag(fragment);
+    /// assert_eq!(res, Ok(5));
+    /// ```
+    ///
+    /// Failing to parse:
+    ///
+    /// ```rust
+    /// # use estring::{EString, ParseFragment, Error, Reason};
+    /// let fragment = EString::from("j");
+    /// let res = i32::parse_frag(fragment.clone());
+    /// assert_eq!(res, Err(Error(fragment, Reason::Parse)));
+    /// ```
     #[inline]
     pub fn parse<T: ParseFragment>(self) -> crate::Result<T> {
         T::parse_frag(self)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,16 +1,31 @@
-/// Failed to parse the specified string.
-#[derive(Debug)]
-pub struct ParseError(pub String);
+use crate::core::EString;
 
-impl std::fmt::Display for ParseError {
+/// The error type for operations interacting with ``EString``’s fragments.
+#[derive(Debug)]
+pub struct Error(pub EString, pub Reason);
+
+/// The reason for the failure to parse.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Reason {
+    /// Cannot split fragment
+    Split,
+    /// Cannot parse fragment
+    Parse,
+}
+
+impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, r#"Failed to parse: "{}""#, self.0)
+        write!(
+            f,
+            r#"Failed to parse "{:?}" with reason {:?}"#,
+            self.0, self.1
+        )
     }
 }
 
-impl std::error::Error for ParseError {}
+impl std::error::Error for Error {}
 
-impl std::ops::Deref for ParseError {
+impl std::ops::Deref for Error {
     type Target = String;
 
     fn deref(&self) -> &Self::Target {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use crate::core::EString;
 
 /// The error type for operations interacting with ``EString``’s fragments.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Error(pub EString, pub Reason);
 
 /// The reason for the failure to parse.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! type PlusVec<T> = SepVec<T, '+'>;
 //! type MulVec<T> = SepVec<T, '*'>;
 //!
-//! fn main() -> Result<(), estring::ParseError> {
+//! fn main() -> estring::Result<()> {
 //!     let res = EString::from("10+5*2+3")
 //!         .parse::<PlusVec<MulVec<f32>>>()?
 //!         .iter()
@@ -32,6 +32,43 @@
 #![warn(missing_docs)]
 
 mod error;
+pub use error::{Error, Reason};
+/// The type returned by parser methods.
+///
+/// # Examples
+///
+/// ```rust
+/// use estring::{EString, ParseFragment, Reason};
+///
+/// #[derive(Debug, PartialEq)]
+/// struct Point {
+///     x: i32,
+///     y: i32,
+/// }
+///
+/// impl ParseFragment for Point {
+///     fn parse_frag(es: EString) -> estring::Result<Self> {
+///         let orig = es.clone();
+///         let (x, y) = es
+///             .trim_matches(|p| p == '(' || p == ')')
+///             .split_once(',')
+///             .ok_or(estring::Error(orig, Reason::Split))?;
+///
+///         let (x, y) = (EString::from(x), EString::from(y));
+///         let x = x.clone().parse::<i32>()
+///             .map_err(|_| estring::Error(x, Reason::Parse))?;
+///         let y = y.clone().parse::<i32>()
+///             .map_err(|_| estring::Error(y, Reason::Parse))?;
+///
+///         Ok(Point { x, y })
+///     }
+/// }
+///
+/// let fragment = EString::from("(1,2)");
+/// let res = Point::parse_frag(fragment).unwrap();
+/// assert_eq!(res, Point { x: 1, y: 2 })
+/// ```
+pub type Result<T> = ::std::result::Result<T, Error>;
 
 pub mod core;
 pub mod std;
@@ -51,4 +88,3 @@ pub mod structs;
 pub use structs::*;
 
 pub use crate::core::*;
-pub use crate::error::ParseError;

--- a/src/low/trim.rs
+++ b/src/low/trim.rs
@@ -1,4 +1,4 @@
-use crate::core::EString;
+use crate::{core::EString, ParseFragment};
 
 /// Wrapper that allow to trim substring before continue
 ///
@@ -9,7 +9,7 @@ use crate::core::EString;
 /// ```rust
 /// use estring::{EString, Trim};
 ///
-/// fn main() -> Result<(), estring::ParseError> {
+/// fn main() -> estring::Result<()> {
 ///     let res = EString::from(" 99 ").parse::<Trim<i32>>()?;
 ///     assert_eq!(res, Trim(99));
 ///     Ok(())
@@ -33,16 +33,12 @@ impl<T: std::fmt::Display> std::fmt::Display for Trim<T> {
     }
 }
 
-impl<T> TryFrom<EString> for Trim<T>
+impl<T> ParseFragment for Trim<T>
 where
-    T: TryFrom<EString>,
+    T: ParseFragment,
 {
-    type Error = ();
-
-    fn try_from(value: EString) -> Result<Self, Self::Error> {
-        T::try_from(EString::from(value.trim()))
-            .map(Trim)
-            .map_err(|_| ())
+    fn parse_frag(value: EString) -> crate::Result<Self> {
+        T::parse_frag(EString::from(value.trim())).map(Trim)
     }
 }
 
@@ -60,7 +56,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "number")]
     #[test]
     fn should_trim_and_convert_to_number() {
         let estr = EString::from("    999   ");

--- a/src/std/bool.rs
+++ b/src/std/bool.rs
@@ -1,14 +1,13 @@
-use crate::core::EString;
+use crate::core::{EString, ParseFragment};
+use crate::error::{Error, Reason};
 
-impl TryFrom<EString> for bool {
-    type Error = ();
-
+impl ParseFragment for bool {
     #[inline]
-    fn try_from(s: EString) -> Result<Self, Self::Error> {
+    fn parse_frag(s: EString) -> crate::Result<Self> {
         match s.to_lowercase().as_str() {
             "true" | "t" | "yes" | "y" | "on" | "1" => Ok(true),
             "false" | "f" | "no" | "n" | "off" | "0" | "" => Ok(false),
-            _ => Err(()),
+            _ => Err(Error(s, Reason::Parse)),
         }
     }
 }
@@ -16,7 +15,6 @@ impl TryFrom<EString> for bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ParseError;
 
     #[test]
     fn should_parse_bool_variable() {
@@ -47,8 +45,9 @@ mod tests {
     fn should_throw_parse_error() {
         let estr = EString::from("something");
         match estr.parse::<bool>() {
-            Err(ParseError(orig)) => {
-                assert_eq!(orig, String::from("something"));
+            Err(crate::Error(orig, reason)) => {
+                assert_eq!(orig, EString::from("something"));
+                assert_eq!(reason, crate::Reason::Parse);
             }
             _ => unreachable!(),
         };

--- a/src/structs/trio.rs
+++ b/src/structs/trio.rs
@@ -63,9 +63,10 @@ where
 mod tests {
     use super::*;
 
+    type EqTrio<A, B, C> = Trio<A, '=', B, '=', C>;
+
     #[test]
     fn should_parse_into_trio() {
-        type EqTrio<A, B, C> = Trio<A, '=', B, '=', C>;
         let estr = EString::from("hello=world=hello");
         match estr.parse::<EqTrio<&str, &str, &str>>() {
             Ok(res) => assert_eq!((res.0, res.1, res.2), ("hello", "world", "hello")),
@@ -75,9 +76,8 @@ mod tests {
 
     #[test]
     fn should_parse_into_trio_with_alternate_delims() {
-        type EqTrio<A, B, C> = Trio<A, '-', B, '^', C>;
         let estr = EString::from("hello-world^hello");
-        match estr.parse::<EqTrio<&str, &str, &str>>() {
+        match estr.parse::<Trio<&str, '-', &str, '^', &str>>() {
             Ok(res) => assert_eq!((res.0, res.1, res.2), ("hello", "world", "hello")),
             _ => unreachable!(),
         };
@@ -85,7 +85,6 @@ mod tests {
 
     #[test]
     fn should_parse_rest_as_trio() {
-        type EqTrio<A, B, C> = Trio<A, '=', B, '=', C>;
         let estr = EString::from("hello=world=hello=world=hello");
         match estr.parse::<EqTrio<&str, &str, EqTrio<&str, &str, &str>>>() {
             Ok(res) => assert_eq!(res, Trio("hello", "world", Trio("hello", "world", "hello"))),


### PR DESCRIPTION
Added two new traits:

- ParseFragment
  ---
  Uses instead of `TryFrom<EString>`. This way we can add this trait for **any** standard and custom types.

- FormatFragment
  ---
  It will use instead `Display`. So we can format to `EString` from any type as we want! For example we can format `Option<T>` to empty string or `T as string`

Closes #24 